### PR TITLE
Feature/update ios sdk

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -26,8 +26,8 @@
     <preference name="FACEBOOK_HYBRID_APP_EVENTS" default="false" />
     <preference name="FACEBOOK_ADVERTISER_ID_COLLECTION" default="true" />
     <preference name="FACEBOOK_ANDROID_SDK_VERSION" default="16.0.1"/>
-    <preference name="FACEBOOK_IOS_SDK_VERSION" default="11.1.0"/>
     <preference name="FACEBOOK_BROWSER_SDK_VERSION" default="v12.0" />
+    <preference name="FACEBOOK_IOS_SDK_VERSION" default="17.0.0"/>
 
     <engines>
         <engine name="cordova-android" version=">=9.0.0" />
@@ -101,6 +101,7 @@
                 <param name="ios-package" value="FacebookConnectPlugin"/>
                 <param name="onload" value="true" />
             </feature>
+             <preference name="deployment-target" value="12.0" />
             <plugin name="FacebookConnectPlugin" value="FacebookConnectPlugin"/>
             <access origin="https://m.facebook.com" />
             <access origin="https://graph.facebook.com" />
@@ -193,12 +194,13 @@
         <!-- Facebook SDK -->
         <podspec>
             <config>
-                <source url="https://github.com/CocoaPods/Specs.git"/>
+                <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods use-frameworks="true">
                 <pod name="FBSDKCoreKit" spec="$FACEBOOK_IOS_SDK_VERSION"/>
                 <pod name="FBSDKLoginKit" spec="$FACEBOOK_IOS_SDK_VERSION"/>
                 <pod name="FBSDKShareKit" spec="$FACEBOOK_IOS_SDK_VERSION"/>
+                <pod name="FBSDKGamingServicesKit" spec="$FACEBOOK_IOS_SDK_VERSION"/>
             </pods>
         </podspec>
 

--- a/src/ios/FacebookConnectPlugin.h
+++ b/src/ios/FacebookConnectPlugin.h
@@ -13,9 +13,8 @@
 #import <FBSDKCoreKit/FBSDKCoreKit.h>
 #import <FBSDKLoginKit/FBSDKLoginKit.h>
 #import <FBSDKShareKit/FBSDKShareKit.h>
-#import <FBSDKCoreKit/FBSDKAppEventsUtility.h>
 #import <AdSupport/ASIdentifierManager.h>
-
+#import <FBSDKGamingServicesKit/FBSDKGamingServicesKit-Swift.h>
 #import <Cordova/CDV.h>
 #import "AppDelegate.h"
 

--- a/src/ios/FacebookConnectPlugin.m
+++ b/src/ios/FacebookConnectPlugin.m
@@ -59,8 +59,8 @@
 }
 
 - (void) applicationDidBecomeActive:(NSNotification *) notification {
-    if (FBSDKSettings.isAutoLogAppEventsEnabled) {
-        [FBSDKAppEvents activateApp];
+    if (FBSDKSettings.sharedSettings.isAutoLogAppEventsEnabled) {
+        [FBSDKAppEvents.shared activateApp];
     }
     if (self.applicationWasActivated == NO) {
         self.applicationWasActivated = YES;
@@ -87,7 +87,7 @@
 }
 
 - (void)getApplicationId:(CDVInvokedUrlCommand *)command {
-    NSString *appID = FBSDKSettings.appID;
+    NSString *appID = FBSDKSettings.sharedSettings.appID;
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:appID];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -100,12 +100,12 @@
     }
 
     NSString *appId = [command argumentAtIndex:0];
-    [FBSDKSettings setAppID:appId];
+    [FBSDKSettings.sharedSettings setAppID:appId];
     [self returnGenericSuccess:command.callbackId];
 }
 
 - (void)getClientToken:(CDVInvokedUrlCommand *)command {
-    NSString *clientToken = FBSDKSettings.clientToken;
+    NSString *clientToken = FBSDKSettings.sharedSettings.clientToken;
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:clientToken];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -116,14 +116,14 @@
         [self returnInvalidArgsError:command.callbackId];
         return;
     }
-    
+
     NSString *clientToken = [command argumentAtIndex:0];
-    [FBSDKSettings setClientToken:clientToken];
+    [FBSDKSettings.sharedSettings setClientToken:clientToken];
     [self returnGenericSuccess:command.callbackId];
 }
 
 - (void)getApplicationName:(CDVInvokedUrlCommand *)command {
-    NSString *displayName = FBSDKSettings.displayName;
+    NSString *displayName = FBSDKSettings.sharedSettings.displayName;
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:displayName];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -136,7 +136,7 @@
     }
 
     NSString *displayName = [command argumentAtIndex:0];
-    [FBSDKSettings setDisplayName:displayName];
+    [FBSDKSettings.sharedSettings setDisplayName:displayName];
     [self returnGenericSuccess:command.callbackId];
 }
 
@@ -148,7 +148,7 @@
 
     BOOL force = [[command argumentAtIndex:0] boolValue];
     if (force) {
-        [FBSDKAccessToken refreshCurrentAccessToken:^(FBSDKGraphRequestConnection *connection, id result, NSError *error) {
+        [FBSDKAccessToken refreshCurrentAccessTokenWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
             CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
                                                           messageAsDictionary:[self loginResponseObject]];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
@@ -181,19 +181,19 @@
 
 - (void)setAutoLogAppEventsEnabled:(CDVInvokedUrlCommand *)command {
     BOOL enabled = [[command argumentAtIndex:0] boolValue];
-    [FBSDKSettings setAutoLogAppEventsEnabled:enabled];
+    [FBSDKSettings.sharedSettings setAutoLogAppEventsEnabled:enabled];
     [self returnGenericSuccess:command.callbackId];
 }
 
 - (void)setAdvertiserIDCollectionEnabled:(CDVInvokedUrlCommand *)command {
     BOOL enabled = [[command argumentAtIndex:0] boolValue];
-    [FBSDKSettings setAdvertiserIDCollectionEnabled:enabled];
+    [FBSDKSettings.sharedSettings setAdvertiserIDCollectionEnabled:enabled];
     [self returnGenericSuccess:command.callbackId];
 }
 
 - (void)setAdvertiserTrackingEnabled:(CDVInvokedUrlCommand *)command {
     BOOL enabled = [[command argumentAtIndex:0] boolValue];
-    [FBSDKSettings setAdvertiserTrackingEnabled:enabled];
+    [FBSDKSettings.sharedSettings setAdvertiserTrackingEnabled:enabled];
     [self returnGenericSuccess:command.callbackId];
 }
 
@@ -206,11 +206,11 @@
 
     NSArray *options = [command argumentAtIndex:0];
     if ([command.arguments count] == 1) {
-        [FBSDKSettings setDataProcessingOptions:options];
+        [FBSDKSettings.sharedSettings setDataProcessingOptions:options];
     } else {
         NSString *country = [command.arguments objectAtIndex:1];
         NSString *state = [command.arguments objectAtIndex:2];
-        [FBSDKSettings setDataProcessingOptions:options country:country state:state];
+        [FBSDKSettings.sharedSettings setDataProcessingOptions:options country:country state:state];
     }
     [self returnGenericSuccess:command.callbackId];
 }
@@ -230,7 +230,7 @@
             [self.commandDelegate sendPluginResult:res callbackId:command.callbackId];
             return;
         } else {
-            [FBSDKAppEvents setUserEmail:(NSString *)params[@"em"]
+            [FBSDKAppEvents.shared setUserEmail:(NSString *)params[@"em"]
                             firstName:(NSString*)params[@"fn"]
                             lastName:(NSString *)params[@"ln"]
                             phone:(NSString *)params[@"ph"]
@@ -247,7 +247,7 @@
 }
 
 - (void)clearUserData:(CDVInvokedUrlCommand *)command {
-    [FBSDKAppEvents clearUserData];
+    [FBSDKAppEvents.shared clearUserData];
     [self returnGenericSuccess:command.callbackId];
 }
 
@@ -266,20 +266,20 @@
         double value;
 
         if ([command.arguments count] == 1) {
-            [FBSDKAppEvents logEvent:eventName];
+            [FBSDKAppEvents.shared logEvent:eventName];
 
         } else {
             // argument count is not 0 or 1, must be 2 or more
             params = [command.arguments objectAtIndex:1];
             if ([command.arguments count] == 2) {
                 // If count is 2 we will just send params
-                [FBSDKAppEvents logEvent:eventName parameters:params];
+                [FBSDKAppEvents.shared logEvent:eventName parameters:params];
             }
 
             if ([command.arguments count] >= 3) {
                 // If count is 3 we will send params and a value to sum
                 value = [[command.arguments objectAtIndex:2] doubleValue];
-                [FBSDKAppEvents logEvent:eventName valueToSum:value parameters:params];
+                [FBSDKAppEvents.shared logEvent:eventName valueToSum:value parameters:params];
             }
         }
         [self returnGenericSuccess:command.callbackId];
@@ -297,10 +297,10 @@
         NSString *currency = [command.arguments objectAtIndex:1];
 
         if ([command.arguments count] == 2 ) {
-            [FBSDKAppEvents logPurchase:value currency:currency];
+            [FBSDKAppEvents.shared logPurchase:value currency:currency];
         } else if ([command.arguments count] >= 3) {
             NSDictionary *params = [command.arguments objectAtIndex:2];
-            [FBSDKAppEvents logPurchase:value currency:currency parameters:params];
+            [FBSDKAppEvents.shared logPurchase:value currency:currency parameters:params];
         }
 
         [self returnGenericSuccess:command.callbackId];
@@ -318,7 +318,7 @@
 
     // this will prevent from being unable to login after updating plugin or changing permissions
     // without refreshing there will be a cache problem. This simple call should fix the problems
-    [FBSDKAccessToken refreshCurrentAccessToken:nil];
+    [FBSDKAccessToken refreshCurrentAccessTokenWithCompletion:nil];
 
     FBSDKLoginManagerLoginResultBlock loginHandler = ^void(FBSDKLoginManagerLoginResult *result, NSError *error) {
         if (error) {
@@ -425,17 +425,17 @@
     NSSet *grantedPermissions = [FBSDKAccessToken currentAccessToken].permissions;
 
     for (NSString *value in permissions) {
-    	NSLog(@"Checking permission %@.", value);
+        NSLog(@"Checking permission %@.", value);
         if (![grantedPermissions containsObject:value]) { //checks if permissions does not exists
             CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
-            												 messageAsString:@"A permission has been denied"];
+                                                             messageAsString:@"A permission has been denied"];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
             return;
         }
     }
 
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
-    												 messageAsString:@"All permissions have been accepted"];
+                                                     messageAsString:@"All permissions have been accepted"];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
     return;
 }
@@ -538,10 +538,10 @@
     } else if ([method isEqualToString:@"share"] || [method isEqualToString:@"feed"]) {
         // Create native params
         self.dialogCallbackId = command.callbackId;
-        FBSDKShareDialog *dialog = [[FBSDKShareDialog alloc] init];
+        FBSDKShareDialog *dialog = [FBSDKShareDialog alloc];
         dialog.fromViewController = [self topMostController];
         if (params[@"photo_image"]) {
-        	FBSDKSharePhoto *photo = [[FBSDKSharePhoto alloc] init];
+            FBSDKSharePhoto *photo = [FBSDKSharePhoto alloc];
         	NSString *photoImage = params[@"photo_image"];
         	if (![photoImage isKindOfClass:[NSString class]]) {
         		NSLog(@"photo_image must be a string");
@@ -551,7 +551,7 @@
         			NSLog(@"photo_image cannot be decoded");
         		} else {
         			photo.image = [UIImage imageWithData:photoImageData];
-        			photo.userGenerated = YES;
+        			photo.isUserGenerated = YES;
         		}
         	}
         	FBSDKSharePhotoContent *content = [[FBSDKSharePhotoContent alloc] init];
@@ -560,7 +560,7 @@
         } else {
         	FBSDKShareLinkContent *content = [[FBSDKShareLinkContent alloc] init];
         	content.contentURL = [NSURL URLWithString:params[@"href"]];
-        	content.hashtag = [FBSDKHashtag hashtagWithString:[params objectForKey:@"hashtag"]];
+            content.hashtag = [[FBSDKHashtag alloc] initWithString:[params objectForKey:@"hashtag"]];
         	content.quote = params[@"quote"];
         	dialog.shareContent = content;
         }
@@ -580,7 +580,7 @@
         return;
     }
     else if ([method isEqualToString:@"apprequests"]) {
-        FBSDKGameRequestDialog *dialog = [[FBSDKGameRequestDialog alloc] init];
+        FBSDKGameRequestDialog *dialog = [FBSDKGameRequestDialog alloc];
         dialog.delegate = self;
         if (![dialog canShow]) {
             CDVPluginResult *pluginResult;
@@ -589,7 +589,7 @@
             return;
         }
 
-        FBSDKGameRequestContent *content = [[FBSDKGameRequestContent alloc] init];
+        FBSDKGameRequestContent *content = [FBSDKGameRequestContent alloc];
         NSString *actionType = params[@"actionType"];
         if (!actionType) {
             NSLog(@"Discarding invalid argument actionType");
@@ -699,7 +699,20 @@
 
     // If we have permissions to request
     if ([permissions count] == 0){
-        [request startWithCompletionHandler:graphHandler];
+        [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
+            CDVPluginResult* pluginResult;
+            if (error) {
+                NSString *message = error.userInfo[FBSDKErrorLocalizedDescriptionKey] ?: @"There was an error making the graph call.";
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                                 messageAsString:message];
+            } else {
+                NSDictionary *response = (NSDictionary *) result;
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:response];
+            }
+            NSLog(@"Finished GraphAPI request");
+
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        }];
         return;
     }
 
@@ -733,7 +746,20 @@
             return;
         }
 
-        [request startWithCompletionHandler:graphHandler];
+        [request startWithCompletion:^(id<FBSDKGraphRequestConnecting>  _Nullable connection, id  _Nullable result, NSError * _Nullable error) {
+            CDVPluginResult* pluginResult;
+            if (error) {
+                NSString *message = error.userInfo[FBSDKErrorLocalizedDescriptionKey] ?: @"There was an error making the graph call.";
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
+                                                 messageAsString:message];
+            } else {
+                NSDictionary *response = (NSDictionary *) result;
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:response];
+            }
+            NSLog(@"Finished GraphAPI request");
+
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        }];
     }];
 }
 
@@ -759,7 +785,7 @@
 
 - (void) activateApp:(CDVInvokedUrlCommand *)command
 {
-    [FBSDKAppEvents activateApp];
+    [FBSDKAppEvents.shared activateApp];
     [self returnGenericSuccess:command.callbackId];
 }
 
@@ -905,7 +931,7 @@
     if ([self.webView isMemberOfClass:[WKWebView class]]){
         NSString *is_enabled = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FacebookHybridAppEvents"];
         if([is_enabled isEqualToString:@"true"]){
-            [FBSDKAppEvents augmentHybridWKWebView:(WKWebView*)self.webView];
+            [FBSDKAppEvents.shared augmentHybridWebView:(WKWebView*)self.webView];
             NSLog(@"FB Hybrid app events are enabled");
         } else {
             NSLog(@"FB Hybrid app events are not enabled");
@@ -1010,7 +1036,7 @@
 
 void FBMethodSwizzle(Class c, SEL originalSelector) {
     NSString *selectorString = NSStringFromSelector(originalSelector);
-    SEL newSelector = NSSelectorFromString([@"swizzled_" stringByAppendingString:selectorString]);
+    SEL newSelector = NSSelectorFromString([@"FacebookConnectPlugin_" stringByAppendingString:selectorString]);
     SEL noopSelector = NSSelectorFromString([@"noop_" stringByAppendingString:selectorString]);
     Method originalMethod, newMethod, noop;
     originalMethod = class_getInstanceMethod(c, originalSelector);
@@ -1028,7 +1054,7 @@ void FBMethodSwizzle(Class c, SEL originalSelector) {
     FBMethodSwizzle([self class], @selector(application:openURL:options:));
 }
 
-- (BOOL)swizzled_application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<NSString *,id> *)options {
+- (BOOL)FacebookConnectPlugin_application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<NSString *,id> *)options {
     if (!url) {
         return NO;
     }
@@ -1041,7 +1067,7 @@ void FBMethodSwizzle(Class c, SEL originalSelector) {
     NSLog(@"FB handle url using application:openURL:options: %@", url);
 
     // Call existing method
-    return [self swizzled_application:application openURL:url options:options];
+    return [self FacebookConnectPlugin_application:application openURL:url options:options];
 }
 
 - (BOOL)noop_application:(UIApplication *)application openURL:(NSURL *)url options:(NSDictionary<NSString *,id> *)options


### PR DESCRIPTION
Only necessary updates for FACEBOOK_IOS_SDK_VERSION 17.0.0

deleted <FBSDKCoreKit/FBSDKAppEventsUtility.h>, cause i think AppEvents is not used anymore

Based on https://github.com/cordova-plugin-facebook-connect/cordova-plugin-facebook-connect/commit/dcd3f84ec49bbc18f9c57e70327f7d3056266b97